### PR TITLE
Config option to check git remote URLs for blacklisted keywords

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ require("presence").setup({
     debounce_timeout    = 10,                         -- Number of seconds to debounce events (or calls to `:lua package.loaded.presence:update(<filename>, true)`)
     enable_line_number  = false,                      -- Displays the current line number instead of the current project
     blacklist           = {},                         -- A list of strings or Lua patterns that disable Rich Presence if the current file name, path, or workspace matches
+    blacklist_repos     = {},                         -- A blacklist that applies to git remote repo URLs instead of folder/file names
     buttons             = true,                       -- Configure Rich Presence button(s), either a boolean to enable/disable, a static table (`{{ label = "<label>", url = "<url>" }, ...}`, or a function(buffer: string, repo_url: string|nil): table)
     file_assets         = {},                         -- Custom file asset definitions keyed by file names and extensions (see default config at `lua/presence/file_assets.lua` for reference)
     show_time           = true,                       -- Show the timer
@@ -69,6 +70,7 @@ let g:presence_log_level
 let g:presence_debounce_timeout    = 10
 let g:presence_enable_line_number  = 0
 let g:presence_blacklist           = []
+let g:presence_blacklist_repos     = []
 let g:presence_buttons             = 1
 let g:presence_file_assets         = {}
 let g:presence_show_time           = 1

--- a/lua/presence/init.lua
+++ b/lua/presence/init.lua
@@ -651,12 +651,10 @@ end
 function Presence:check_blacklist(buffer, parent_dirpath, project_dirpath)
     local parent_dirname = nil
     local project_dirname = nil
-    local git_repo
 
     -- Parse parent/project directory name
     if parent_dirpath then
         parent_dirname = self.get_filename(parent_dirpath, self.os.path_separator)
-        git_repo = Presence:get_git_repo_url(parent_dirpath)
     end
 
     if project_dirpath then
@@ -683,20 +681,30 @@ function Presence:check_blacklist(buffer, parent_dirpath, project_dirpath)
         end
 
         -- Match project either by Lua pattern or by plain string
-        local is_git_repo_blacklisted = git_repo and
-            ((git_repo:match(val) == git_repo) == git_repo or
-            (git_repo:find(val, nil, true)))
-        if is_git_repo_blacklisted then
-            return true
-        end
-
-        -- Match project either by Lua pattern or by plain string
         local is_project_directory_blacklisted = project_dirpath and
             ((project_dirpath:match(val) == project_dirpath or
             project_dirname:match(val) == project_dirname) or
             (project_dirpath:find(val, nil, true) or
             project_dirname:find(val, nil, true)))
         if is_project_directory_blacklisted then
+            return true
+        end
+    end
+
+
+    -- check against git repo blacklist
+    local git_repo = Presence:get_git_repo_url(parent_dirpath)
+    local blacklist_repos_table = self.options["blacklist_repos"] or {}
+
+
+    for _, val in pairs(blacklist_repos_table) do
+        if buffer:match(val) == buffer then return true end
+
+        local is_git_repo_blacklisted = git_repo and
+            ((git_repo:match(val) == git_repo) == git_repo or
+            (git_repo:find(val, nil, true)))
+
+        if is_git_repo_blacklisted then
             return true
         end
     end

--- a/lua/presence/init.lua
+++ b/lua/presence/init.lua
@@ -130,6 +130,7 @@ function Presence:setup(...)
     self:set_option("workspace_text", "Working on %s")
     self:set_option("line_number_text", "Line %s out of %s")
     self:set_option("blacklist", {})
+    self:set_option("blacklist_repos", {})
     self:set_option("buttons", true)
     self:set_option("show_time", true)
     -- File assets options
@@ -661,10 +662,9 @@ function Presence:check_blacklist(buffer, parent_dirpath, project_dirpath)
         project_dirname = self.get_filename(project_dirpath, self.os.path_separator)
     end
 
-    print(git_repo)
-
     -- Blacklist table
-    local blacklist_table = self.options["blacklist"]
+    local blacklist_table = self.options["blacklist"] or {}
+    local blacklist_repos_table = self.options["blacklist_repos"] or {}
 
     -- Loop over the values to see if the provided project/path is in the blacklist
     for _, val in pairs(blacklist_table) do
@@ -694,7 +694,12 @@ function Presence:check_blacklist(buffer, parent_dirpath, project_dirpath)
 
     -- check against git repo blacklist
     local git_repo = Presence:get_git_repo_url(parent_dirpath)
-    local blacklist_repos_table = self.options["blacklist_repos"] or {}
+    if git_repo then
+      self.log:debug(string.format("Checking git repo blacklist for %s", git_repo))
+    else
+      self.log:debug("No git repo, skipping blacklist check")
+      return false
+    end
 
 
     for _, val in pairs(blacklist_repos_table) do
@@ -821,10 +826,11 @@ function Presence:update_for_buffer(buffer, should_debounce)
     local project_name, project_path = self:get_project_name(parent_dirpath)
 
     -- Check for blacklist
-    local is_blacklisted = #self.options.blacklist > 0 and self:check_blacklist(buffer, parent_dirpath, project_path)
+    local blacklist_not_empty = (#self.options.blacklist > 0 or #self.options.blacklist_repos > 0)
+    local is_blacklisted = blacklist_not_empty and self:check_blacklist(buffer, parent_dirpath, project_path)
     if is_blacklisted then
         self.last_activity.file = buffer
-        self.log:debug("Either project or directory name is blacklisted, skipping...")
+        self.log:debug("Either project, directory name, or repository URL is blacklisted. Skipping...")
         self:cancel()
         return
     end


### PR DESCRIPTION
Adds a new config option for blacklisting strings found in git repo URLs.
```
blacklist_repos = {
  -- strings to match git remote urls for
}
```
Was originally kinda confused why blacklists weren't working, since the readme mentioned "workspace" and I guess I just assumed that meant git repos. This should clear things up.

[#48] Config option to check git remote URLs for blacklisted keywords

https://openproject.stefka.eu/work_packages/48

