### PR TITLE
fix(ci/cd): Use cache, Luacheck not working on Gitea

### DIFF
--- a/.github/workflows/luacheck.yml
+++ b/.github/workflows/luacheck.yml
@@ -4,7 +4,14 @@ jobs:
   Luacheck:
     runs-on: ubuntu-latest
     steps:
+      - name: Update repositories
+        run: sudo apt update
+      - name: Install luarocks
+        uses: awalsh128/cache-apt-pkgs-action@latest
+        with:
+          packages: lua-check
       - name: Checkout
         uses: actions/checkout@v3
       - name: Luacheck linter
-        uses: lunarmodules/luacheck@v1
+        run: luacheck --config .luacheckrc .
+        # uses: lunarmodules/luacheck@v1

--- a/.github/workflows/luacheck.yml
+++ b/.github/workflows/luacheck.yml
@@ -14,4 +14,3 @@ jobs:
         uses: actions/checkout@v3
       - name: Luacheck linter
         run: luacheck --config .luacheckrc .
-        # uses: lunarmodules/luacheck@v1

--- a/.github/workflows/stylua.yml
+++ b/.github/workflows/stylua.yml
@@ -4,8 +4,12 @@ jobs:
   StyLuacheck:
     runs-on: ubuntu-latest
     steps:
+      - name: Update repositories
+        run: sudo apt update
       - name: Install cargo
-        run: sudo apt update && sudo apt install -y cargo
+        uses: awalsh128/cache-apt-pkgs-action@latest
+        with:
+          packages: cargo
 
       - name: Install StyLua from crates.io
         uses: baptiste0928/cargo-install@v3

--- a/.github/workflows/stylua.yml
+++ b/.github/workflows/stylua.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install cargo
-        run: apt update && apt install -y cargo
+        run: sudo apt update && sudo apt install -y cargo
 
       - name: Install StyLua from crates.io
         uses: baptiste0928/cargo-install@v3

--- a/.github/workflows/stylua.yml
+++ b/.github/workflows/stylua.yml
@@ -4,6 +4,9 @@ jobs:
   StyLuacheck:
     runs-on: ubuntu-latest
     steps:
+      - name: Install cargo
+        run: apt update && apt install -y cargo
+
       - name: Install StyLua from crates.io
         uses: baptiste0928/cargo-install@v3
         with:


### PR DESCRIPTION
`apt` did not use cache (`sudo apt install cargo` always installed it which took unnecessarily long)
Luacheck action failed (`luacheck` wasn't installed probably)
  - Converted to `apt` (+ cache) and manual `luacheck` run

[#69] Make workflow compatible with medium act images

https://openproject.stefka.eu/work_packages/69